### PR TITLE
Adjusted how equals and hash works with pieces and the board

### DIFF
--- a/src/main/java/ChessLogic.java
+++ b/src/main/java/ChessLogic.java
@@ -66,10 +66,10 @@ public class ChessLogic {
     private boolean isRepetition(){
         if(board.getNumFullMoves() < 4)
             return false;
-        int boardState = board.getState();
+        int boardState = board.hashCode();
         for(int i = 0; i < 2; i++){
             board.undoMultipleMoves(4);
-            if(boardState != board.getState()) {
+            if(boardState != board.hashCode()) {
                 board.redoAllMoves();
                 return false;
             }

--- a/src/main/java/Chessboard.java
+++ b/src/main/java/Chessboard.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /** A chess board that is automatically populated with blank squares. */
 public class Chessboard {
@@ -134,12 +135,17 @@ public class Chessboard {
         history.push(move);
     }
 
-    /** Gets the hash of the board. The previous moves is not included in this calculation, only the state of each
-     * piece. */
-    public int getState(){
-        return Arrays.deepHashCode(board);
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof Chessboard otherChessboard)) return false;
+        return Objects.deepEquals(board, otherChessboard.board) && currentTurn == otherChessboard.currentTurn;
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.deepHashCode(board), currentTurn);
+    }
 
     public void setCurrentTurn(PieceColour newTurn){currentTurn = newTurn;}
 

--- a/src/main/java/Chessboard.java
+++ b/src/main/java/Chessboard.java
@@ -144,7 +144,13 @@ public class Chessboard {
 
     @Override
     public int hashCode() {
-        return Objects.hash(Arrays.deepHashCode(board), currentTurn);
+        int hash = 0;
+        for(Piece[] row : board){
+            for(Piece piece : row){
+                hash += Objects.hash(piece, piece.getX(), piece.getY());
+            }
+        }
+        return hash;
     }
 
     public void setCurrentTurn(PieceColour newTurn){currentTurn = newTurn;}

--- a/src/main/java/Piece.java
+++ b/src/main/java/Piece.java
@@ -60,7 +60,8 @@ public abstract class Piece {
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;
         Piece piece = (Piece) obj;
-        return startX == piece.startX && startY == piece.startY && colour == piece.colour;
+        return startX == piece.startX && x == piece.x && y == piece.y &&
+                startY == piece.startY && colour == piece.colour;
     }
 
     @Override

--- a/src/main/java/Piece.java
+++ b/src/main/java/Piece.java
@@ -8,12 +8,16 @@ import java.util.Objects;
  * An abstract class which parents all chess pieces.
  */
 public abstract class Piece {
+    private final int startX;
+    private final int startY;
     private Icon pieceIcon;
     protected final PieceColour colour;
     protected int x;
     protected int y;
 
     protected Piece(int x, int y, PieceColour colour) {
+        startX = x;
+        startY = y;
         this.x = x;
         this.y = y;
         this.colour = colour;
@@ -56,12 +60,12 @@ public abstract class Piece {
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;
         Piece piece = (Piece) obj;
-        return x == piece.x && y == piece.y && colour == piece.colour;
+        return startX == piece.startX && startY == piece.startY && colour == piece.colour;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(x, y, colour, toCharacter());
+        return Objects.hash(startX, startY, colour, toCharacter());
     }
 
     public Icon getPieceIcon() {

--- a/src/test/java/ChessboardTest.java
+++ b/src/test/java/ChessboardTest.java
@@ -65,38 +65,38 @@ class ChessboardTest {
 
     @Test
     void hashcodeOnSameState(){
-        int state = board.getState();
-        assertEquals(state, board.getState());
+        int state = board.hashCode();
+        assertEquals(state, board.hashCode());
     }
 
     @Test
     void hashcodeTestOnBasicPawnMoveWithUndo() {
-        int state = board.getState();
+        int state = board.hashCode();
         assertDoesNotThrow(()->board.makeMove(4, 1, 4, 3));
-        assertNotEquals(state, board.getState());
+        assertNotEquals(state, board.hashCode());
         board.undoMove();
-        assertEquals(state, board.getState());
+        assertEquals(state, board.hashCode());
     }
 
     @Test
     void hashcodeTestOnMoveWherePreviousWasPassantable() {
         assertDoesNotThrow(()->board.makeMove(4, 1, 4, 3));
-        int state = board.getState();
+        int state = board.hashCode();
         int whitePawnHash = board.getPiece(4,3).hashCode();
         int blackPawnHash = board.getPiece(4,6).hashCode();
         int blankSquareHash = board.getPiece(4, 4).hashCode();
         assertDoesNotThrow(()->board.makeMove(4, 6, 4, 4));
-        assertNotEquals(state, board.getState());
+        assertNotEquals(state, board.hashCode());
         board.undoMove();
         assertEquals(whitePawnHash, board.getPiece(4,3).hashCode());
         assertEquals(blackPawnHash, board.getPiece(4,6).hashCode());
         assertEquals(blankSquareHash, board.getPiece(4, 4).hashCode());
-        assertEquals(state, board.getState());
+        assertEquals(state, board.hashCode());
     }
 
     @Test
     void undoMoreThanNecessary(){
-        int state = board.getState();
+        int state = board.hashCode();
         assertDoesNotThrow(()->board.makeMove(3, 1, 3, 3));
         assertDoesNotThrow(()->board.makeMove(4, 6, 4, 4));
         assertDoesNotThrow(()->board.makeMove(3, 3, 4, 4));
@@ -105,7 +105,7 @@ class ChessboardTest {
         board.undoMove();
         board.undoMove();
         board.undoMove();
-        assertEquals(state, board.getState());
+        assertEquals(state, board.hashCode());
     }
 
 
@@ -114,7 +114,7 @@ class ChessboardTest {
         assertDoesNotThrow(()->board.makeMove(3, 1, 3, 3));
         assertDoesNotThrow(()->board.makeMove(4, 6, 4, 4));
         assertDoesNotThrow(()->board.makeMove(3, 3, 4, 4));
-        int state = board.getState();
+        int state = board.hashCode();
         board.undoMove();
         board.undoMove();
         board.undoMove();
@@ -124,6 +124,6 @@ class ChessboardTest {
         board.redoMove();
         board.redoMove();
         board.redoMove();
-        assertEquals(state, board.getState());
+        assertEquals(state, board.hashCode());
     }
 }


### PR DESCRIPTION
When calculating the hash of a piece, it only uses the original position of the piece.
Equals it uses the original position and the actual position.
Board uses the actual position for both equals and hash.